### PR TITLE
First implementation of product-gifts blocks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
-📢 Use this project, [contribute](https://github.com/vtex-apps/product-gifts) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
+<!-- 📢 Use this project, [contribute](https://github.com/vtex-apps/product-gifts) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion). -->
 
-# Product Gifts
+📢 **This project is a work-in-progress, this app is not read for use yet.**
+
+# [WIP] Product Gifts
 
 Under the block's name, you should explain the topic, giving a **brief description** of the **block's functionality** in a store.
 

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "vtex.product-context": "0.x",
     "vtex.search-graphql": "0.x",
-    "vtex.native-types": "0.x"
+    "vtex.native-types": "0.x",
+    "vtex.store-image": "0.x",
+    "vtex.css-handles": "0.x"
   },
   "registries": [
     "smartcheckout"

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,11 @@
     "store": "0.x",
     "docs": "0.x"
   },
-  "dependencies": {},
+  "dependencies": {
+    "vtex.product-context": "0.x",
+    "vtex.search-graphql": "0.x",
+    "vtex.native-types": "0.x"
+  },
   "registries": [
     "smartcheckout"
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -14,11 +14,10 @@
     "vtex.search-graphql": "0.x",
     "vtex.native-types": "0.x",
     "vtex.store-image": "0.x",
-    "vtex.css-handles": "0.x"
+    "vtex.css-handles": "0.x",
+    "vtex.responsive-values": "0.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/ProductGiftDescription.tsx
+++ b/react/ProductGiftDescription.tsx
@@ -1,0 +1,19 @@
+import React, { FC, useContext } from 'react'
+import { useCssHandles } from 'vtex.css-handles'
+
+import { GiftContext } from './components/ProductGift'
+
+const CSS_HANDLES = ['giftDescription']
+
+const ProductGiftDescription: FC = () => {
+  const handles = useCssHandles(CSS_HANDLES)
+  const gift = useContext(GiftContext)
+
+  return (
+    <span className={`${handles.giftDescription} t-small c-muted-1`}>
+      {gift?.description}
+    </span>
+  )
+}
+
+export default ProductGiftDescription

--- a/react/ProductGiftDescription.tsx
+++ b/react/ProductGiftDescription.tsx
@@ -1,13 +1,13 @@
-import React, { FC, useContext } from 'react'
+import React, { FC } from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 
-import { GiftContext } from './components/ProductGift'
+import { useGift } from './components/ProductGift'
 
 const CSS_HANDLES = ['giftDescription']
 
 const ProductGiftDescription: FC = () => {
   const handles = useCssHandles(CSS_HANDLES)
-  const gift = useContext(GiftContext)
+  const gift = useGift()
 
   return (
     <span className={`${handles.giftDescription} t-small c-muted-1`}>

--- a/react/ProductGiftDescription.tsx
+++ b/react/ProductGiftDescription.tsx
@@ -3,7 +3,7 @@ import { useCssHandles } from 'vtex.css-handles'
 
 import { useGift } from './components/ProductGift'
 
-const CSS_HANDLES = ['giftDescription']
+const CSS_HANDLES = ['giftDescription'] as const
 
 const ProductGiftDescription: FC = () => {
   const handles = useCssHandles(CSS_HANDLES)

--- a/react/ProductGiftImage.tsx
+++ b/react/ProductGiftImage.tsx
@@ -29,7 +29,7 @@ const ProductGiftImage: FC<Props> = ({
       minHeight={minHeight}
       src={gift?.images[imageIndex].imageUrl}
       alt={gift?.productName}
-      title={gift?.productTitle}
+      title={gift?.skuName}
     />
   )
 }

--- a/react/ProductGiftImage.tsx
+++ b/react/ProductGiftImage.tsx
@@ -1,0 +1,37 @@
+import React, { FC, useContext } from 'react'
+import { Image } from 'vtex.store-image'
+
+import { GiftContext } from './components/ProductGift'
+
+interface Props {
+  maxWidth?: string | number
+  maxHeight?: string | number
+  minWidth?: string | number
+  minHeight?: string | number
+  imageIndex?: number
+}
+
+const DEFAULT_IMAGE_DIMENSIONS = 125
+
+const ProductGiftImage: FC<Props> = ({
+  maxWidth = DEFAULT_IMAGE_DIMENSIONS,
+  maxHeight = DEFAULT_IMAGE_DIMENSIONS,
+  minWidth = DEFAULT_IMAGE_DIMENSIONS,
+  minHeight = DEFAULT_IMAGE_DIMENSIONS,
+  imageIndex = 0,
+}) => {
+  const gift = useContext(GiftContext)
+  return (
+    <Image
+      maxWidth={maxWidth}
+      maxHeight={maxHeight}
+      minWidth={minWidth}
+      minHeight={minHeight}
+      src={gift?.images[imageIndex].imageUrl}
+      alt={gift?.productName}
+      title={gift?.productTitle}
+    />
+  )
+}
+
+export default ProductGiftImage

--- a/react/ProductGiftImage.tsx
+++ b/react/ProductGiftImage.tsx
@@ -8,7 +8,7 @@ interface Props {
   maxHeight?: string | number
   minWidth?: string | number
   minHeight?: string | number
-  imageIndex?: number
+  imageLabel?: string
 }
 
 const DEFAULT_IMAGE_DIMENSIONS = 125
@@ -18,9 +18,11 @@ const ProductGiftImage: FC<Props> = ({
   maxHeight = DEFAULT_IMAGE_DIMENSIONS,
   minWidth = DEFAULT_IMAGE_DIMENSIONS,
   minHeight = DEFAULT_IMAGE_DIMENSIONS,
-  imageIndex = 0,
+  imageLabel,
 }) => {
   const gift = useGift()
+  const productImage =
+    gift.images.find(image => image.imageLabel === imageLabel) ?? gift.images[0]
 
   return (
     <Image
@@ -28,9 +30,9 @@ const ProductGiftImage: FC<Props> = ({
       maxHeight={maxHeight}
       minWidth={minWidth}
       minHeight={minHeight}
-      src={gift?.images[imageIndex].imageUrl}
-      alt={gift?.productName}
-      title={gift?.skuName}
+      src={productImage.imageUrl}
+      alt={gift.productName}
+      title={gift.skuName}
     />
   )
 }

--- a/react/ProductGiftImage.tsx
+++ b/react/ProductGiftImage.tsx
@@ -1,7 +1,7 @@
-import React, { FC, useContext } from 'react'
+import React, { FC } from 'react'
 import { Image } from 'vtex.store-image'
 
-import { GiftContext } from './components/ProductGift'
+import { useGift } from './components/ProductGift'
 
 interface Props {
   maxWidth?: string | number
@@ -20,7 +20,8 @@ const ProductGiftImage: FC<Props> = ({
   minHeight = DEFAULT_IMAGE_DIMENSIONS,
   imageIndex = 0,
 }) => {
-  const gift = useContext(GiftContext)
+  const gift = useGift()
+
   return (
     <Image
       maxWidth={maxWidth}

--- a/react/ProductGiftList.tsx
+++ b/react/ProductGiftList.tsx
@@ -4,7 +4,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import { useProductGiftsState } from './ProductGiftsContext'
 import ProductGift from './components/ProductGift'
 
-const CSS_HANDLES = ['productGiftListContainer']
+const CSS_HANDLES = ['productGiftListContainer'] as const
 
 const ProductGiftList: FC = ({ children }) => {
   const { gifts, maxVisibleItems } = useProductGiftsState()

--- a/react/ProductGiftList.tsx
+++ b/react/ProductGiftList.tsx
@@ -13,7 +13,7 @@ const ProductGiftList: FC = ({ children }) => {
     maxVisibleItems === 'showAll' ? gifts.length : maxVisibleItems
 
   return (
-    <div className={`${handles.productGiftListContainer} mv5`}>
+    <div className={handles.productGiftListContainer}>
       {gifts.slice(0, itemsToShow).map((gift, idx) => (
         <ProductGift key={gift.skuName} giftIndex={idx}>
           {children}

--- a/react/ProductGiftList.tsx
+++ b/react/ProductGiftList.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from 'react'
+import { useCssHandles } from 'vtex.css-handles'
+
+import { useProductGiftsState } from './ProductGiftsContext'
+import ProductGift from './components/ProductGift'
+
+const CSS_HANDLES = ['productGiftListContainer']
+
+const ProductGiftList: FC = ({ children }) => {
+  const { gifts, maxVisibleItems } = useProductGiftsState()
+  const handles = useCssHandles(CSS_HANDLES)
+  const itemsToShow =
+    maxVisibleItems === 'showAll' ? gifts.length : maxVisibleItems
+
+  return (
+    <div className={`${handles.productGiftListContainer} mv5`}>
+      {gifts.slice(0, itemsToShow).map((gift, idx) => (
+        <ProductGift key={gift.linkText} giftIndex={idx}>
+          {children}
+        </ProductGift>
+      ))}
+    </div>
+  )
+}
+
+export default ProductGiftList

--- a/react/ProductGiftList.tsx
+++ b/react/ProductGiftList.tsx
@@ -15,7 +15,7 @@ const ProductGiftList: FC = ({ children }) => {
   return (
     <div className={`${handles.productGiftListContainer} mv5`}>
       {gifts.slice(0, itemsToShow).map((gift, idx) => (
-        <ProductGift key={gift.nameComplete} giftIndex={idx}>
+        <ProductGift key={gift.skuName} giftIndex={idx}>
           {children}
         </ProductGift>
       ))}

--- a/react/ProductGiftList.tsx
+++ b/react/ProductGiftList.tsx
@@ -15,7 +15,7 @@ const ProductGiftList: FC = ({ children }) => {
   return (
     <div className={`${handles.productGiftListContainer} mv5`}>
       {gifts.slice(0, itemsToShow).map((gift, idx) => (
-        <ProductGift key={gift.linkText} giftIndex={idx}>
+        <ProductGift key={gift.nameComplete} giftIndex={idx}>
           {children}
         </ProductGift>
       ))}

--- a/react/ProductGiftName.tsx
+++ b/react/ProductGiftName.tsx
@@ -1,8 +1,8 @@
-import React, { FC, useContext } from 'react'
+import React, { FC } from 'react'
 import { Link } from 'vtex.render-runtime'
 import { useCssHandles } from 'vtex.css-handles'
 
-import { GiftContext } from './components/ProductGift'
+import { useGift } from './components/ProductGift'
 
 interface Props {
   linkToProductPage: boolean
@@ -12,7 +12,7 @@ const CSS_HANDLES = ['giftNameLink', 'giftNameText']
 
 const ProductGiftName: FC<Props> = ({ linkToProductPage = true }) => {
   const handles = useCssHandles(CSS_HANDLES)
-  const gift = useContext(GiftContext)
+  const gift = useGift()
 
   return linkToProductPage ? (
     <Link

--- a/react/ProductGiftName.tsx
+++ b/react/ProductGiftName.tsx
@@ -1,0 +1,31 @@
+import React, { FC, useContext } from 'react'
+import { Link } from 'vtex.render-runtime'
+import { useCssHandles } from 'vtex.css-handles'
+
+import { GiftContext } from './components/ProductGift'
+
+interface Props {
+  linkToProductPage: boolean
+}
+
+const CSS_HANDLES = ['giftNameLink', 'giftNameText']
+
+const ProductGiftName: FC<Props> = ({ linkToProductPage = true }) => {
+  const handles = useCssHandles(CSS_HANDLES)
+  const gift = useContext(GiftContext)
+
+  return linkToProductPage ? (
+    <Link
+      className={`${handles.giftNameLink} c-on-base link`}
+      href={`/${gift?.linkText}/p`}
+    >
+      <span className={`${handles.giftNameText}`}>{gift?.nameComplete}</span>
+    </Link>
+  ) : (
+    <span className={`${handles.giftNameText} c-on-base`}>
+      {gift?.nameComplete}
+    </span>
+  )
+}
+
+export default ProductGiftName

--- a/react/ProductGiftName.tsx
+++ b/react/ProductGiftName.tsx
@@ -19,12 +19,10 @@ const ProductGiftName: FC<Props> = ({ linkToProductPage = true }) => {
       className={`${handles.giftNameLink} c-on-base link`}
       href={`/${gift?.linkText}/p`}
     >
-      <span className={`${handles.giftNameText}`}>{gift?.nameComplete}</span>
+      <span className={`${handles.giftNameText}`}>{gift?.skuName}</span>
     </Link>
   ) : (
-    <span className={`${handles.giftNameText} c-on-base`}>
-      {gift?.nameComplete}
-    </span>
+    <span className={`${handles.giftNameText} c-on-base`}>{gift?.skuName}</span>
   )
 }
 

--- a/react/ProductGiftName.tsx
+++ b/react/ProductGiftName.tsx
@@ -8,21 +8,21 @@ interface Props {
   linkToProductPage: boolean
 }
 
-const CSS_HANDLES = ['giftNameLink', 'giftNameText']
+const CSS_HANDLES = ['giftNameLink', 'giftNameText'] as const
 
-const ProductGiftName: FC<Props> = ({ linkToProductPage = true }) => {
+const ProductGiftName: FC<Props> = ({ linkToProductPage = false }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const gift = useGift()
 
   return linkToProductPage ? (
     <Link
       className={`${handles.giftNameLink} c-on-base link`}
-      href={`/${gift?.linkText}/p`}
+      href={`/${gift.linkText}/p`}
     >
-      <span className={`${handles.giftNameText}`}>{gift?.skuName}</span>
+      <span className={`${handles.giftNameText}`}>{gift.skuName}</span>
     </Link>
   ) : (
-    <span className={`${handles.giftNameText} c-on-base`}>{gift?.skuName}</span>
+    <span className={`${handles.giftNameText} c-on-base`}>{gift.skuName}</span>
   )
 }
 

--- a/react/ProductGiftText.tsx
+++ b/react/ProductGiftText.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { IOMessage } from 'vtex.native-types'
+import { useCssHandles } from 'vtex.css-handles'
+
+import { useProductGiftsState } from './ProductGiftsContext'
+
+interface Props {
+  translatableText: string
+}
+
+const CSS_HANDLES = ['productGiftText']
+
+const ProductGiftText: StorefrontFunctionComponent<Props> = ({
+  translatableText,
+}) => {
+  const { gifts, maxVisibleItems } = useProductGiftsState()
+  const handles = useCssHandles(CSS_HANDLES)
+  const resolvedMaxVisibleItems =
+    maxVisibleItems === 'showAll' ? gifts.length : maxVisibleItems
+
+  const values = {
+    totalGifts: gifts.length,
+    exceedingItems:
+      gifts.length - resolvedMaxVisibleItems > 0
+        ? gifts.length - resolvedMaxVisibleItems
+        : 0,
+    visibleItems:
+      resolvedMaxVisibleItems > gifts.length
+        ? gifts.length
+        : resolvedMaxVisibleItems,
+  }
+
+  return (
+    <IOMessage id={translatableText} values={values}>
+      {(message: string) => (
+        <span className={handles.productGiftText}>{message}</span>
+      )}
+    </IOMessage>
+  )
+}
+
+ProductGiftText.schema = {
+  title: 'ProductGifts',
+  description: 'A test, for now.',
+  type: 'Object',
+}
+
+export default ProductGiftText

--- a/react/ProductGiftText.tsx
+++ b/react/ProductGiftText.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { IOMessage } from 'vtex.native-types'
 import { useCssHandles } from 'vtex.css-handles'
 
@@ -8,7 +8,7 @@ interface Props {
   translatableText: string
 }
 
-const CSS_HANDLES = ['productGiftText']
+const CSS_HANDLES = ['productGiftText'] as const
 
 const ProductGiftText: StorefrontFunctionComponent<Props> = ({
   translatableText,
@@ -18,24 +18,25 @@ const ProductGiftText: StorefrontFunctionComponent<Props> = ({
   const resolvedMaxVisibleItems =
     maxVisibleItems === 'showAll' ? gifts.length : maxVisibleItems
 
-  const values = {
-    totalGifts: gifts.length,
-    exceedingItems:
-      gifts.length - resolvedMaxVisibleItems > 0
-        ? gifts.length - resolvedMaxVisibleItems
-        : 0,
-    visibleItems:
-      resolvedMaxVisibleItems > gifts.length
-        ? gifts.length
-        : resolvedMaxVisibleItems,
-  }
+  const values = useMemo(
+    () => ({
+      totalGifts: gifts.length,
+      exceedingItems:
+        gifts.length - resolvedMaxVisibleItems > 0
+          ? gifts.length - resolvedMaxVisibleItems
+          : 0,
+      visibleItems:
+        resolvedMaxVisibleItems > gifts.length
+          ? gifts.length
+          : resolvedMaxVisibleItems,
+    }),
+    [gifts.length, resolvedMaxVisibleItems]
+  )
 
   return (
-    <IOMessage id={translatableText} values={values}>
-      {(message: string) => (
-        <span className={handles.productGiftText}>{message}</span>
-      )}
-    </IOMessage>
+    <span className={handles.productGiftText}>
+      <IOMessage id={translatableText} values={values} />
+    </span>
   )
 }
 

--- a/react/ProductGifts.tsx
+++ b/react/ProductGifts.tsx
@@ -1,0 +1,17 @@
+import React, { FC } from 'react'
+
+import { ProductGiftsContextProvider } from './ProductGiftsContext'
+
+interface Props {
+  maxVisibleItems: number | 'showAll'
+}
+
+const ProductGifts: FC<Props> = ({ children, maxVisibleItems = 'showAll' }) => {
+  return (
+    <ProductGiftsContextProvider maxVisibleItems={maxVisibleItems}>
+      {children}
+    </ProductGiftsContextProvider>
+  )
+}
+
+export default ProductGifts

--- a/react/ProductGifts.tsx
+++ b/react/ProductGifts.tsx
@@ -1,14 +1,22 @@
 import React, { FC } from 'react'
+import {
+  useResponsiveValue,
+  MaybeResponsiveInput,
+} from 'vtex.responsive-values'
 
 import { ProductGiftsContextProvider } from './ProductGiftsContext'
 
 interface Props {
-  maxVisibleItems: number | 'showAll'
+  maxVisibleItems: MaybeResponsiveInput<number | 'showAll'>
 }
 
 const ProductGifts: FC<Props> = ({ children, maxVisibleItems = 'showAll' }) => {
+  const staticMaxVisibleItems = useResponsiveValue<number | 'showAll'>(
+    maxVisibleItems
+  )
+
   return (
-    <ProductGiftsContextProvider maxVisibleItems={maxVisibleItems}>
+    <ProductGiftsContextProvider maxVisibleItems={staticMaxVisibleItems}>
       {children}
     </ProductGiftsContextProvider>
   )

--- a/react/ProductGifts.tsx
+++ b/react/ProductGifts.tsx
@@ -3,6 +3,7 @@ import {
   useResponsiveValue,
   MaybeResponsiveInput,
 } from 'vtex.responsive-values'
+import { useCssHandles } from 'vtex.css-handles'
 
 import { ProductGiftsContextProvider } from './ProductGiftsContext'
 
@@ -10,14 +11,17 @@ interface Props {
   maxVisibleItems: MaybeResponsiveInput<number | 'showAll'>
 }
 
+const CSS_HANDLES = ['productGiftsContainer'] as const
+
 const ProductGifts: FC<Props> = ({ children, maxVisibleItems = 'showAll' }) => {
+  const handles = useCssHandles(CSS_HANDLES)
   const staticMaxVisibleItems = useResponsiveValue<number | 'showAll'>(
     maxVisibleItems
   )
 
   return (
     <ProductGiftsContextProvider maxVisibleItems={staticMaxVisibleItems}>
-      {children}
+      <div className={handles.productGiftsContainer}>{children}</div>
     </ProductGiftsContextProvider>
   )
 }

--- a/react/ProductGiftsContext.tsx
+++ b/react/ProductGiftsContext.tsx
@@ -9,7 +9,10 @@ interface State extends Props {
   gifts: Gift[]
 }
 
-const GiftsStateContext = createContext<State | undefined>(undefined)
+const GiftsStateContext = createContext<State>({
+  gifts: [],
+  maxVisibleItems: 0,
+})
 
 const ProductGiftsContextProvider: FC<Props> = ({
   children,

--- a/react/ProductGiftsContext.tsx
+++ b/react/ProductGiftsContext.tsx
@@ -1,0 +1,53 @@
+import React, {
+  createContext,
+  useState,
+  useContext,
+  FC,
+  useEffect,
+} from 'react'
+import useProduct from 'vtex.product-context/useProduct'
+
+interface Props {
+  maxVisibleItems: number | 'showAll'
+}
+
+interface State extends Props {
+  gifts: Gift[]
+}
+
+const GiftsStateContext = createContext<State | undefined>(undefined)
+
+const ProductGiftsContextProvider: FC<Props> = ({
+  children,
+  maxVisibleItems,
+}) => {
+  const productContext: Maybe<ProductContextState> = useProduct()
+  const [state, setState] = useState<State>({ gifts: [], maxVisibleItems })
+
+  useEffect(() => {
+    const sellers = productContext?.selectedItem?.sellers
+    const gifts =
+      sellers?.reduce((acc: Gift[], curr) => {
+        return [...acc, ...(curr.commertialOffer.gifts || [])]
+      }, []) ?? []
+    setState(currState => ({ ...currState, gifts }))
+  }, [state, productContext])
+
+  return (
+    <GiftsStateContext.Provider value={state}>
+      {children}
+    </GiftsStateContext.Provider>
+  )
+}
+
+function useProductGiftsState() {
+  const context = useContext(GiftsStateContext)
+  if (context === undefined) {
+    throw new Error(
+      'useProductGiftsState must be used within a ProductGiftsContextProvider'
+    )
+  }
+  return context
+}
+
+export { ProductGiftsContextProvider, useProductGiftsState }

--- a/react/ProductGiftsContext.tsx
+++ b/react/ProductGiftsContext.tsx
@@ -18,25 +18,24 @@ const ProductGiftsContextProvider: FC<Props> = ({
   const productContext: Maybe<ProductContextState> = useProduct()
   const selectedItemFromContext = productContext?.selectedItem
 
-  const giftsMemoized = useMemo(() => {
-    const sellers = selectedItemFromContext?.sellers ?? []
-    const gifts =
-      sellers?.reduce((acc: Gift[], curr) => {
-        acc.push(...(curr.commertialOffer.gifts || []))
-        return acc
-      }, []) ?? []
+  const sellers = selectedItemFromContext?.sellers ?? []
+  const gifts =
+    sellers?.reduce((acc: Gift[], curr) => {
+      acc.push(...(curr.commertialOffer.gifts || []))
+      return acc
+    }, []) ?? []
 
-    return gifts
-  }, [selectedItemFromContext])
+  const state = useMemo(() => ({ gifts, maxVisibleItems }), [
+    gifts,
+    maxVisibleItems,
+  ])
 
-  if (!productContext || giftsMemoized.length === 0) {
+  if (!productContext || state.gifts.length === 0) {
     return null
   }
 
   return (
-    <GiftsStateContext.Provider
-      value={{ gifts: giftsMemoized, maxVisibleItems }}
-    >
+    <GiftsStateContext.Provider value={state}>
       {children}
     </GiftsStateContext.Provider>
   )

--- a/react/ProductGiftsContext.tsx
+++ b/react/ProductGiftsContext.tsx
@@ -1,10 +1,4 @@
-import React, {
-  createContext,
-  useState,
-  useContext,
-  FC,
-  useEffect,
-} from 'react'
+import React, { createContext, useContext, FC } from 'react'
 import useProduct from 'vtex.product-context/useProduct'
 
 interface Props {
@@ -22,19 +16,19 @@ const ProductGiftsContextProvider: FC<Props> = ({
   maxVisibleItems,
 }) => {
   const productContext: Maybe<ProductContextState> = useProduct()
-  const [state, setState] = useState<State>({ gifts: [], maxVisibleItems })
 
-  useEffect(() => {
-    const sellers = productContext?.selectedItem?.sellers
-    const gifts =
-      sellers?.reduce((acc: Gift[], curr) => {
-        return [...acc, ...(curr.commertialOffer.gifts || [])]
-      }, []) ?? []
-    setState(currState => ({ ...currState, gifts }))
-  }, [state, productContext])
+  if (!productContext) {
+    return null
+  }
+
+  const sellers = productContext?.selectedItem?.sellers
+  const gifts =
+    sellers?.reduce((acc: Gift[], curr) => {
+      return [...acc, ...(curr.commertialOffer.gifts || [])]
+    }, []) ?? []
 
   return (
-    <GiftsStateContext.Provider value={state}>
+    <GiftsStateContext.Provider value={{ gifts, maxVisibleItems }}>
       {children}
     </GiftsStateContext.Provider>
   )

--- a/react/components/ProductGift.tsx
+++ b/react/components/ProductGift.tsx
@@ -1,4 +1,4 @@
-import React, { FC, createContext } from 'react'
+import React, { FC, createContext, useContext } from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 
 import { useProductGiftsState } from '../ProductGiftsContext'
@@ -22,6 +22,16 @@ const ProductGift: FC<Props> = ({ giftIndex, children }) => {
       </div>
     </GiftContext.Provider>
   )
+}
+
+export function useGift() {
+  const context = useContext(GiftContext)
+  if (context === undefined) {
+    throw new Error(
+      'useProductGift must be used within a ProductGiftContextProvider'
+    )
+  }
+  return context
 }
 
 export default ProductGift

--- a/react/components/ProductGift.tsx
+++ b/react/components/ProductGift.tsx
@@ -1,0 +1,27 @@
+import React, { FC, createContext } from 'react'
+import { useCssHandles } from 'vtex.css-handles'
+
+import { useProductGiftsState } from '../ProductGiftsContext'
+
+interface Props {
+  giftIndex: number
+}
+
+const CSS_HANDLES = ['giftListItem']
+
+export const GiftContext = createContext<Gift | undefined>(undefined)
+
+const ProductGift: FC<Props> = ({ giftIndex, children }) => {
+  const { gifts: giftSkuInfo } = useProductGiftsState()
+  const handles = useCssHandles(CSS_HANDLES)
+
+  return (
+    <GiftContext.Provider value={giftSkuInfo[giftIndex]}>
+      <div className={`${handles.giftListItem} br3 ba b--muted-3 mv2 pa5`}>
+        {children}
+      </div>
+    </GiftContext.Provider>
+  )
+}
+
+export default ProductGift

--- a/react/components/ProductGift.tsx
+++ b/react/components/ProductGift.tsx
@@ -7,7 +7,7 @@ interface Props {
   giftIndex: number
 }
 
-const CSS_HANDLES = ['giftListItem']
+const CSS_HANDLES = ['giftListItem'] as const
 
 export const GiftContext = createContext<Gift | undefined>(undefined)
 

--- a/react/typings/Product.ts
+++ b/react/typings/Product.ts
@@ -149,7 +149,7 @@ interface Seller {
     AvailableQuantity: number
     Tax: number
     CacheVersionUsedToCallCheckout: string
-    giftSkuIds: Gift[]
+    gifts: Gift[]
   }
 }
 
@@ -159,10 +159,6 @@ interface Gift {
   linkText: string
   description: string
   productTitle: string
-  skuItem: GiftSkuItem
-}
-
-interface GiftSkuItem {
   nameComplete: string
   images: GiftImage[]
 }

--- a/react/typings/Product.ts
+++ b/react/typings/Product.ts
@@ -158,8 +158,7 @@ interface Gift {
   brand: string
   linkText: string
   description: string
-  productTitle: string
-  nameComplete: string
+  skuName: string
   images: GiftImage[]
 }
 

--- a/react/typings/Product.ts
+++ b/react/typings/Product.ts
@@ -1,0 +1,337 @@
+type Maybe<T> = T | null | undefined
+
+interface OrderForm {
+  items: Item[]
+  shipping?: Shipping
+  marketingData: Maybe<OrderFormMarketingData>
+  totalizers: Array<{
+    id: string
+    name: string
+    value: number
+  }>
+  value: number
+  messages: OrderFormMessages
+}
+
+interface OrderFormItemInput {
+  id?: number
+  index?: number
+  quantity?: number
+  seller?: string
+  uniqueId?: string
+  options?: AssemblyOptionInput[]
+}
+
+interface AssemblyOptionItem {
+  id: string
+  quantity: number
+  seller: string
+  initialQuantity: number
+  choiceType: 'SINGLE' | 'TOGGLE' | 'MULTIPLE'
+  name: string
+  price: number
+  children: Record<string, AssemblyOptionItem[]> | null
+}
+
+interface BuyButtonContextState {
+  clicked: boolean
+}
+
+interface ProductContextState {
+  selectedItem: Maybe<ProductContextItem>
+  product: Maybe<Product>
+  selectedQuantity: number
+  skuSelector: {
+    isVisible: boolean
+    areAllVariationsSelected: boolean
+  }
+  buyButton: BuyButtonContextState
+  assemblyOptions: {
+    items: Record<string, AssemblyOptionItem[]>
+    inputValues: Record<string, InputValues>
+    areGroupsValid: Record<string, boolean>
+  }
+}
+
+type InputValues = Record<string, string>
+
+interface Product {
+  cacheId: string
+  productName: string
+  productId: string
+  description: string
+  titleTag: string
+  metaTagDescription: string
+  linkText: string
+  productReference: string
+  categoryId: string
+  categoriesIds: string[]
+  categories: string[]
+  categoryTree: Array<{
+    id: string
+    name: string
+    href: string
+  }>
+  brand: string
+  brandId: string
+  properties: Array<{
+    name: string
+    values: string
+  }>
+  specificationGroups: Array<{
+    name: string
+    specifications: Array<{
+      name: string
+      values: string[]
+    }>
+  }>
+  items: ProductContextItem[]
+  itemMetadata: {
+    items: ItemMetadata[]
+    priceTable: any[]
+  }
+}
+
+interface ProductContextItem {
+  itemId: string
+  name: string
+  nameComplete: string
+  complementName: string
+  ean: string
+  referenceId: Array<{
+    Key: string
+    Value: string
+  }>
+  measurementUnit: string
+  unitMultiplier: number
+  images: Array<{
+    imageId: string
+    imageLabel: string
+    imageTag: string
+    imageUrl: string
+    imageText: string
+  }>
+  videos: Array<{
+    videoUrl: string
+  }>
+  sellers: Seller[]
+  variations: Array<{
+    name: string
+    values: string[]
+  }>
+  productClusters: Array<{
+    id: string
+    name: string
+  }>
+  clusterHighlights: Array<{
+    id: string
+    name: string
+  }>
+}
+
+interface Seller {
+  sellerId: string
+  sellerName: string
+  addToCartLink: string
+  sellerDefault: string
+  commertialOffer: {
+    discountHighlights: Array<{
+      name: string
+    }>
+    teasers: Array<{
+      name: string
+    }>
+    Price: number
+    ListPrice: number
+    PriceWithoutDiscount: number
+    RewardValue: number
+    PriceValidUntil: string
+    AvailableQuantity: number
+    Tax: number
+    CacheVersionUsedToCallCheckout: string
+    giftSkuIds: Gift[]
+  }
+}
+
+interface Gift {
+  productName: string
+  brand: string
+  linkText: string
+  description: string
+  productTitle: string
+  skuItem: GiftSkuItem
+}
+
+interface GiftSkuItem {
+  nameComplete: string
+  images: GiftImage[]
+}
+
+interface GiftImage {
+  imageUrl: string
+  imageLabel: string
+  imageText: string
+}
+
+interface ItemMetadata {
+  items: Array<{
+    id: string
+    name: string
+    imageUrl: string
+    seller: string
+    assemblyOptions: {
+      id: string
+      name: string
+      required: boolean
+      inputValues: InputValue[]
+      composition: Composition | null
+    }
+  }>
+  priceTable: Array<{
+    type: string
+    values: Array<{
+      id: string
+      assemblyId: string
+      price: number | null
+    }>
+  }>
+}
+
+type InputValue = TextInputValue | BooleanInputValue | OptionsInputValue
+
+enum InputValueType {
+  'TEXT' = 'TEXT',
+  'BOOLEAN' = 'BOOLEAN',
+  'OPTIONS' = 'OPTIONS',
+}
+
+interface TextInputValue {
+  type: InputValueType.TEXT
+  defaultValue: ''
+  label: string
+  maxLength: number
+  domain: null
+}
+
+interface BooleanInputValue {
+  type: InputValueType.BOOLEAN
+  defaultValue: boolean
+  label: string
+  maxLength: null
+  domain: null
+}
+
+interface OptionsInputValue {
+  type: InputValueType.OPTIONS
+  defaultValue: string
+  label: string
+  maxLength: null
+  domain: string[]
+}
+
+interface Composition {
+  minQuantity: number
+  maxQuantity: number
+  items: Array<{
+    id: string
+    minQuantity: number
+    maxQuantity: number
+    priceTable: string
+    seller: string
+    initialQuantity: number
+  }>
+}
+
+interface OrderFormMarketingData {
+  utmCampaign?: string
+  utmMedium?: string
+  utmSource?: string
+  utmiCampaign?: string
+  utmiPart?: string
+  utmipage?: string
+  marketingTags?: string
+  coupon?: string
+}
+
+interface Shipping {
+  availableAddresses: CheckoutAddress[]
+  countries: string[]
+  deliveryOptions: DeliveryOption[]
+  selectedAddress: CheckoutAddress | null
+}
+
+interface CheckoutAddress {
+  addressId: string
+  addressType: string
+  city: string | null
+  complement: string | null
+  country: string
+  geoCoordinates: number[]
+  neighborhood: string | null
+  number: string | null
+  postalCode: string | null
+  receiverName: string | null
+  reference: string | null
+  state: string | null
+  street: string | null
+}
+
+interface DeliveryOption {
+  id: string
+  price: number
+  estimate: string
+  isSelected: boolean
+}
+
+interface OrderFormMessages {
+  couponMessages: Message[]
+  generalMessages: Message[]
+}
+
+interface Message {
+  code: string
+  text: string
+  status: string
+}
+
+interface AssemblyOptionInput {
+  id?: string
+  quantity?: number
+  assemblyId: string
+  seller?: string
+  inputValues?: Record<string, string | boolean>
+  options?: AssemblyOptionInput[]
+}
+
+interface Item {
+  additionalInfo: {
+    brandName: string
+    brandId: string
+    offeringInfo: any | null
+    offeringType: any | null
+    offeringTypeId: any | null
+  }
+  availability: string
+  detailUrl: string
+  id: string
+  imageUrls?: {
+    at1x: string
+    at2x: string
+    at3x: string
+  }
+  listPrice: number
+  measurementUnit: string
+  name: string
+  price: number
+  productId: string
+  quantity: number
+  sellingPrice: number
+  skuName: string
+  skuSpecifications: SKUSpecification[]
+  uniqueId: string
+}
+
+interface SKUSpecification {
+  fieldName: string
+  fieldValues: string[]
+}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,0 +1,8 @@
+import { FunctionComponent } from 'react'
+
+declare global {
+  interface StorefrontFunctionComponent<P = {}> extends FunctionComponent<P> {
+    schema?: object
+    getSchema?(props?: P): object
+  }
+}

--- a/react/typings/graphql.ts
+++ b/react/typings/graphql.ts
@@ -1,0 +1,4 @@
+declare module '*.graphql' {
+  const graphql: any
+  export default graphql
+}

--- a/react/typings/vtex.css-handles.d.ts
+++ b/react/typings/vtex.css-handles.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.css-handles'

--- a/react/typings/vtex.native-types.d.ts
+++ b/react/typings/vtex.native-types.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.native-types'

--- a/react/typings/vtex.product-context.ts
+++ b/react/typings/vtex.product-context.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.product-context/useProduct'

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.render-runtime'

--- a/react/typings/vtex.responsive-values.d.ts
+++ b/react/typings/vtex.responsive-values.d.ts
@@ -1,0 +1,21 @@
+declare module 'vtex.responsive-values' {
+  enum InputDevices {
+    mobile = 'mobile',
+    phone = 'phone',
+    tablet = 'tablet',
+    desktop = 'desktop',
+  }
+
+  enum OutputDevices {
+    phone = 'phone',
+    tablet = 'tablet',
+    desktop = 'desktop',
+  }
+
+  type ResponsiveInput<T> = { [P in keyof typeof InputDevices]?: T }
+  type MaybeResponsiveInput<T> = T | ResponsiveInput<T>
+
+  type ResponsiveOutput<T> = { [P in keyof typeof OutputDevices]: T }
+
+  export function useResponsiveValue<T>(args: MaybeResponsiveInput<T>): T
+}

--- a/react/typings/vtex.store-image.d.ts
+++ b/react/typings/vtex.store-image.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.store-image'

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,0 +1,22 @@
+{
+  "product-gifts": {
+    "component": "ProductGifts",
+    "composition": "children"
+  },
+  "product-gift-list": {
+    "component": "ProductGiftList",
+    "composition": "children"
+  },
+  "gift-name": {
+    "component": "ProductGiftName"
+  },
+  "gift-image": {
+    "component": "ProductGiftImage"
+  },
+  "gift-text": {
+    "component": "ProductGiftText"
+  },
+  "gift-description": {
+    "component": "ProductGiftDescription"
+  }
+}


### PR DESCRIPTION
#### What does this PR do?

This is the first implementation of `vtex.product-gifts` app, which provides the following apps to be used in stores:

- `product-gifts`
- `product-gift-list`
- `gift-name`
- `gift-image`
- `gift-text`
- `gift-description`

This implementation was based in the discussion here: https://github.com/vtex-apps/store-discussion/issues/174

Notice that it is still a work-in-progress and will not be published yet.

#### How to test it?

[Workspace](https://productgifts--storecomponents.myvtex.com/gorgeous-watch/p)

#### Related to / Depends on

This depends on:

- https://github.com/vtex-apps/search-graphql/pull/51
- https://github.com/vtex-apps/store-resources/pull/98
