### PR TITLE
skip query if context has no product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Avoid making query if context has no product.
 
 ## [0.2.0] - 2020-03-11
 ### Added

--- a/react/ProductGifts.tsx
+++ b/react/ProductGifts.tsx
@@ -37,7 +37,7 @@ const ProductGifts: StoreFunctionComponent<Props> = ({
       variables: {
         identifier: { field: 'id', value: productContext?.product?.productId },
       },
-      skip: !productContext?.product?.productId,
+      skip: productContext?.product?.productId == null,
     }
   )
   const selectedItemId = productContext?.selectedItem?.itemId

--- a/react/ProductGifts.tsx
+++ b/react/ProductGifts.tsx
@@ -37,6 +37,7 @@ const ProductGifts: StoreFunctionComponent<Props> = ({
       variables: {
         identifier: { field: 'id', value: productContext?.product?.productId },
       },
+      skip: !productContext?.product?.productId,
     }
   )
   const selectedItemId = productContext?.selectedItem?.itemId


### PR DESCRIPTION
#### What does this PR do? \*

If productContext had no product, you were doing a query with no id field, which cannot happen and throws an error

#### How to test it? \*
https://fidelis--storecomponents.myvtex.com/jumper-best-friend/p

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
